### PR TITLE
ENV Redis Url

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,13 +12,9 @@ Sidekiq.configure_server do |config|
     chain.add SidekiqMiddleware
   end
 
-  if Rails.env == 'production'
-    config.redis = { url: 'redis://bridgeapi-sidekiq.zocofw.0001.use2.cache.amazonaws.com:6379/0' }
-  end
+  config.redis = { url: ENV['REDIS_URL'] } if Rails.env == 'production'
 end
 
 Sidekiq.configure_client do |config|
-  if Rails.env == 'production'
-    config.redis = { url: 'redis://bridgeapi-sidekiq.zocofw.0001.use2.cache.amazonaws.com:6379/0' }
-  end
+  config.redis = { url: ENV['REDIS_URL'] } if Rails.env == 'production'
 end


### PR DESCRIPTION
Use env var instead of hardcoding production redis url. Already been tested in a deploy.