### PR TITLE
Events controller using current user specs

### DIFF
--- a/spec/requests/events_request_spec.rb
+++ b/spec/requests/events_request_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe 'EventsController', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'returns 400 with bridge_id when user doesn\'t own event' do
+    it 'returns 404 with bridge_id when user doesn\'t own event' do
       @token = JsonWebToken.encode(user_id: User.second)
       get '/events', headers: authenticated_token, params: { bridge_id: @bridge.id }
       expect(response).to have_http_status(:not_found)
     end
 
-    it 'returns 400 with event_id when user doesn\'t own event' do
+    it 'returns 404 with event_id when user doesn\'t own event' do
       @token = JsonWebToken.encode(user_id: User.second)
       get '/events', headers: authenticated_token, params: { event_id: @event.id }
       expect(response).to have_http_status(:not_found)
@@ -71,13 +71,13 @@ RSpec.describe 'EventsController', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'returns 400 with bridge_id when user doesn\'t own event' do
+    it 'returns 404 with bridge_id when user doesn\'t own event' do
       @token = JsonWebToken.encode(user_id: User.second)
       get "/events/#{@event.id}", headers: authenticated_token, params: { bridge_id: @bridge.id }
       expect(response).to have_http_status(:not_found)
     end
 
-    it 'returns 400 with id when user doesn\'t own event' do
+    it 'returns 404 with id when user doesn\'t own event' do
       @token = JsonWebToken.encode(user_id: User.second)
       get "/events/#{@event.id}", headers: authenticated_token
       expect(response).to have_http_status(:not_found)
@@ -101,6 +101,12 @@ RSpec.describe 'EventsController', type: :request do
     it 'returns 204' do
       delete "/events/#{@event.id}", headers: authenticated_token, params: { event_id: @event.id }
       expect(response).to have_http_status(204)
+    end
+
+    it 'returns 404 when user doesn\'t own event' do
+      @token = JsonWebToken.encode(user_id: User.second)
+      delete "/events/#{@event.id}", headers: authenticated_token, params: { event_id: @event.id }
+      expect(response).to have_http_status(:not_found)
     end
 
     it 'returns 400 with invalid IDs' do

--- a/spec/requests/events_request_spec.rb
+++ b/spec/requests/events_request_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe 'EventsController', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'returns 400 with bridge_id when user doesn\'t own event' do
+      @token = JsonWebToken.encode(user_id: User.second)
+      get "/events/#{@event.id}", headers: authenticated_token, params: { bridge_id: @bridge.id }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns 400 with id when user doesn\'t own event' do
+      @token = JsonWebToken.encode(user_id: User.second)
+      get "/events/#{@event.id}", headers: authenticated_token
+      expect(response).to have_http_status(:not_found)
+    end
+
     it 'returns 400 with invalid IDs' do
       get '/events/128371283', headers: authenticated_token, params: { event_id: '128371283' }
       expect(response).to have_http_status(400)

--- a/spec/requests/events_request_spec.rb
+++ b/spec/requests/events_request_spec.rb
@@ -57,7 +57,17 @@ RSpec.describe 'EventsController', type: :request do
 
   describe 'GET show' do
     it 'returns 200 with bridge_id' do
+      get "/events/#{@event.id}", headers: authenticated_token, params: { bridge_id: @bridge.id }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 with event_id' do
       get "/events/#{@event.id}", headers: authenticated_token, params: { event_id: @event.id }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 with id' do
+      get "/events/#{@event.id}", headers: authenticated_token
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/events_request_spec.rb
+++ b/spec/requests/events_request_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe 'EventsController', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'returns 400 with bridge_id when user doesn\'t own event' do
+      @token = JsonWebToken.encode(user_id: User.second)
+      get '/events', headers: authenticated_token, params: { bridge_id: @bridge.id }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns 400 with event_id when user doesn\'t own event' do
+      @token = JsonWebToken.encode(user_id: User.second)
+      get '/events', headers: authenticated_token, params: { event_id: @event.id }
+      expect(response).to have_http_status(:not_found)
+    end
+
     it 'returns 400 with no params' do
       get '/events', headers: authenticated_token
       expect(response).to have_http_status(400)


### PR DESCRIPTION
Index, show, and delete actions are now being tested to ensure their use of `@current_user`